### PR TITLE
Added convenience constructor that takes DispatchTimeInterval for dur…

### DIFF
--- a/src/common/DispatchTimeIntervalToSeconds.swift
+++ b/src/common/DispatchTimeIntervalToSeconds.swift
@@ -1,0 +1,32 @@
+/*
+ Copyright 2016-present The Material Motion Authors. All Rights Reserved.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+extension DispatchTimeInterval {
+  func toSeconds() -> CGFloat {
+    let seconds: CGFloat
+    switch self {
+    case let .seconds(arg):
+      seconds = CGFloat(arg)
+    case let .milliseconds(arg):
+      seconds = CGFloat(arg) / 1000.0
+    case let .microseconds(arg):
+      seconds = CGFloat(arg) / 1000000.0
+    case let .nanoseconds(arg):
+      seconds = CGFloat(arg) / 1000000000.0
+    }
+    return seconds
+  }
+}

--- a/src/interactions/PathTween.swift
+++ b/src/interactions/PathTween.swift
@@ -69,6 +69,14 @@ public final class PathTween: Interaction, Togglable, Stateful {
   }
 
   /**
+   Initializes a path tween instance with its required properties.
+   */
+  convenience public init(duration: DispatchTimeInterval, path: CGPath, system: @escaping PathTweenToStream<CGPoint> = coreAnimation, timeline: Timeline? = nil) {
+    let durationInSeconds = duration.toSeconds()
+    self.init(duration: durationInSeconds, path: path, system: system, timeline: timeline)
+  }
+
+  /**
    Initializes a path tween instance with a default duration of 0 and an empty path.
 
    The duration and path should be modified after initialization in order to configure the

--- a/src/interactions/TransitionTween.swift
+++ b/src/interactions/TransitionTween.swift
@@ -73,6 +73,21 @@ public final class TransitionTween<T>: Tween<T> {
     super.init(duration: duration, values: values, system: system, timeline: timeline)
   }
 
+  /**
+   Creates a transition tween.
+   
+   - parameter system: Often coreAnimation. Can be another system if a system support library is available.
+   */
+  convenience public init(duration: DispatchTimeInterval,
+              forwardValues: [T],
+              direction: ReactiveProperty<TransitionDirection>,
+              forwardKeyPositions: [CGFloat] = [],
+              system: @escaping TweenToStream<T> = coreAnimation,
+              timeline: Timeline? = nil) {
+    let durationInSeconds = duration.toSeconds()
+    self.init(duration: durationInSeconds, forwardValues: forwardValues, direction: direction, forwardKeyPositions: forwardKeyPositions, system: system, timeline: timeline)
+  }
+  
   public override func add(to property: ReactiveProperty<T>,
                            withRuntime runtime: MotionRuntime,
                            constraints: ConstraintApplicator<T>? = nil) {

--- a/src/interactions/Tween.swift
+++ b/src/interactions/Tween.swift
@@ -102,6 +102,14 @@ public class Tween<T>: Interaction, Togglable, Stateful {
     self.timeline = timeline
   }
 
+  /**
+   Initializes a tween instance with its required properties.
+   */
+  convenience public init(duration: DispatchTimeInterval, values: [T], system: @escaping TweenToStream<T> = coreAnimation, timeline: Timeline? = nil) {
+    let durationInSeconds = duration.toSeconds()
+    self.init(duration: durationInSeconds, values: values, system: system, timeline: timeline)
+  }
+
   public func add(to property: ReactiveProperty<T>,
                   withRuntime runtime: MotionRuntime,
                   constraints applyConstraints: ConstraintApplicator<T>? = nil) {

--- a/src/operators/delayBy.swift
+++ b/src/operators/delayBy.swift
@@ -42,4 +42,12 @@ extension MotionObservableConvertible {
       }
     }
   }
+
+  /**
+   Emits values from upstream after the specified delay.
+   */
+  public func delay(by duration: DispatchTimeInterval) -> MotionObservable<T> {
+    let durationInSeconds = duration.toSeconds()
+    return self.delay(by: durationInSeconds)
+  }
 }

--- a/tests/unit/operator/delayTests.swift
+++ b/tests/unit/operator/delayTests.swift
@@ -37,6 +37,24 @@ class delayTests: XCTestCase {
     subscription.unsubscribe()
   }
 
+  func testValueIsDelayedUsingDispatchTimeInterval() {
+    let property = createProperty()
+    
+    var hasReceived = false
+    let didReceiveValue = expectation(description: "Did receive value")
+    let subscription = property.delay(by: .milliseconds(500)).subscribeToValue { value in
+      XCTAssertEqual(value, 0)
+      didReceiveValue.fulfill()
+      hasReceived = true
+    }
+    
+    XCTAssertFalse(hasReceived)
+    
+    waitForExpectations(timeout: 0.5)
+    
+    subscription.unsubscribe()
+  }
+  
   func testValueIsNotReceivedWithoutSubscription() {
     let property = createProperty()
 


### PR DESCRIPTION
…ation

Summary:
We currently use CGFloat for duration but we wanted to include DispatchTimeInterval because of it’s cleaner time APIs.

Tags: #material_motion

Usage:
delay(by: .milliseconds(500))
delay(by: .seconds(1))