### PR TITLE
Resolve Xcode 9 build failures

### DIFF
--- a/src/common/DispatchTimeIntervalToSeconds.swift
+++ b/src/common/DispatchTimeIntervalToSeconds.swift
@@ -20,6 +20,21 @@ import CoreGraphics
 extension DispatchTimeInterval {
   func toSeconds() -> CGFloat {
     let seconds: CGFloat
+
+#if swift(>=3.2)
+    switch self {
+    case let .seconds(arg):
+      seconds = CGFloat(arg)
+    case let .milliseconds(arg):
+      seconds = CGFloat(arg) / 1000.0
+    case let .microseconds(arg):
+      seconds = CGFloat(arg) / 1000000.0
+    case let .nanoseconds(arg):
+      seconds = CGFloat(arg) / 1000000000.0
+    case .never:
+      seconds = CGFloat.infinity
+    }
+#else
     switch self {
     case let .seconds(arg):
       seconds = CGFloat(arg)
@@ -30,6 +45,7 @@ extension DispatchTimeInterval {
     case let .nanoseconds(arg):
       seconds = CGFloat(arg) / 1000000000.0
     }
+#endif
     return seconds
   }
 }

--- a/src/common/DispatchTimeIntervalToSeconds.swift
+++ b/src/common/DispatchTimeIntervalToSeconds.swift
@@ -21,6 +21,23 @@ extension DispatchTimeInterval {
   func toSeconds() -> CGFloat {
     let seconds: CGFloat
 
+    // `.never` was introduced in the latest SDK. In order to support both Xcode 8 and 9 we have to
+    // implement the `case .never` while not implementing it on Xcode 8. Unfortunately, `#if swift`
+    // statements placed inside of switch statements can't build, so we're stuck duplicating the
+    // switch statement.
+    //
+    // If we try to write the code like so:
+    //
+    //     #if swift(>=3.2)
+    //       case .never:
+    //       seconds = CGFloat.infinity
+    //     #endif
+    //
+    // We get the following errors:
+    //
+    //     Extraneous '.' in enum 'case' declaration
+    //     'case' label can only appear inside a 'switch' statement
+
 #if swift(>=3.2)
     switch self {
     case let .seconds(arg):

--- a/src/interactions/Spring.swift
+++ b/src/interactions/Spring.swift
@@ -45,7 +45,7 @@ public let defaultSpringMass: CGFloat = 1
 
  T-value constraints may be applied to this interaction.
  */
-public class Spring<T>: Interaction, Togglable, Stateful where T: Zeroable, T: Subtractable {
+public class Spring<T>: Interaction, Togglable, Stateful where T: ZeroableAndSubtractable {
   /**
    Creates a spring with a given threshold and system.
 
@@ -138,7 +138,7 @@ public class Spring<T>: Interaction, Togglable, Stateful where T: Zeroable, T: S
   private var activeSprings = Set<SpringShadow<T>>()
 }
 
-public struct SpringShadow<T>: Hashable where T: Zeroable, T: Subtractable {
+public struct SpringShadow<T>: Hashable where T: ZeroableAndSubtractable {
   public let enabled: ReactiveProperty<Bool>
   public let state = createProperty(withInitialValue: MotionState.atRest)
   public let initialValue: ReactiveProperty<T>

--- a/src/interactions/TransitionSpring.swift
+++ b/src/interactions/TransitionSpring.swift
@@ -61,7 +61,7 @@ public let defaultTransitionSpringSuggestedDuration: CGFloat = 0.5
 
  T-value constraints may be applied to this interaction.
  */
-public final class TransitionSpring<T>: Spring<T> where T: Zeroable, T: Subtractable {
+public final class TransitionSpring<T>: Spring<T> where T: ZeroableAndSubtractable {
 
   /**
    The destination when the transition is moving backward.

--- a/src/protocols/ZeroableAndSubtractable.swift
+++ b/src/protocols/ZeroableAndSubtractable.swift
@@ -1,0 +1,30 @@
+/*
+ Copyright 2016-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+import UIKit
+
+extension CGPoint: ZeroableAndSubtractable {
+}
+
+extension CGSize: ZeroableAndSubtractable {
+}
+
+extension CGRect: ZeroableAndSubtractable {
+}
+
+extension CGFloat: ZeroableAndSubtractable {
+}

--- a/src/protocols/ZeroableAndSubtractable.swift
+++ b/src/protocols/ZeroableAndSubtractable.swift
@@ -1,5 +1,5 @@
 /*
- Copyright 2016-present The Material Motion Authors. All Rights Reserved.
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/systems/coreAnimationSpringToStream.swift
+++ b/src/systems/coreAnimationSpringToStream.swift
@@ -22,7 +22,7 @@ import UIKit
 
  Only works with Subtractable types due to use of additive animations.
  */
-public func coreAnimation<T>(_ spring: SpringShadow<T>) -> (MotionObservable<T>) where T: Subtractable {
+public func coreAnimation<T>(_ spring: SpringShadow<T>) -> (MotionObservable<T>) {
   let initialVelocityStream = spring.initialVelocity.asStream()
   return MotionObservable { observer in
     var animationKeys: [String] = []


### PR DESCRIPTION
Type aliases in Swift only allow us to indicate that `T` conforms to a single type, so in order to specify that our spring `T` conforms to `Zeroable` and `Subtractable` we introduced a composite type, `ZeroableAndSubtractable`. Prior to Swift 3.2 conforming to `Zeroable` and `Subtractable` appeared sufficient to meet the check for conforming to `ZeroableAndSubtractable`. With Swift 3.2 it appears this is no longer sufficient, so we need to declare explicit conformity to `ZeroableAndSubtractable` where applicable.